### PR TITLE
Potential fix for code scanning alert no. 1: Binding a socket to all network interfaces

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,7 @@ def http_server():
 
     # Find an available port
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('', 0))
+        s.bind(('localhost', 0))
         port = s.getsockname()[1]
 
     server = HTTPServer(('localhost', port), TestHandler)


### PR DESCRIPTION
Potential fix for [https://github.com/Rigohl/PythonWebScraper/security/code-scanning/1](https://github.com/Rigohl/PythonWebScraper/security/code-scanning/1)

To fix the problem, we should bind the temporary socket used for discovering a free port to the local loopback interface, not all interfaces. This is achieved by replacing `s.bind(('', 0))` with `s.bind(('localhost', 0))` or `s.bind(('127.0.0.1', 0))`. Since the HTTP server is already started on `('localhost', port)`, using `localhost` in the socket binding maintains consistent behavior and restricts access to the local interface. No new imports or additional methods are required. Only one line in the `http_server` fixture of `tests/conftest.py` needs changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Change socket.bind in http_server fixture to use ('localhost', 0) instead of ('', 0)